### PR TITLE
Properly ignore resaved pages when reading PS2

### DIFF
--- a/kernel/power/tuxonice_io.c
+++ b/kernel/power/tuxonice_io.c
@@ -668,11 +668,9 @@ top:
                         if (!PageResave(pfn_to_page(write_pfn)))
                                 use_read_page(write_pfn, buffer);
                         else {
-                                mutex_lock(&io_mutex);
                                 toi_message(TOI_IO, TOI_VERBOSE, 0,
                                                 "Resaved %ld.", write_pfn);
-                                atomic_inc(&io_count);
-                                mutex_unlock(&io_mutex);
+                                memory_bm_clear_bit(io_map, smp_processor_id(), write_pfn);
                         }
                 }
 


### PR DESCRIPTION
Incrementing io_count leads to a BUG() in do_rw_loop():

Finished I/O loop but still work to do?
Finish at = 35771. io_count = 32.

Here, io_count = 32 is the number of resaved pages.

Instead of fiddling with io_count, do what use_read_page() would
normally do, just ignore the page contents.

Signed-off-by: Tomáš Trnka <tomastrnka@gmx.com>